### PR TITLE
Board visual  improvements

### DIFF
--- a/data/ui/game_page.blp
+++ b/data/ui/game_page.blp
@@ -33,25 +33,13 @@ Adw.Bin game_page {
       valign: center;
       halign: center;
 
-      Gtk.Box board {
-        orientation: vertical;
+      // TODO: Add a breakpoint that will set a higher content size when window width is >= 600px
+      Gtk.DrawingArea draw_area {
+        hexpand: true;
+        vexpand: true;
 
-        // TODO: Add a breakpoint that will set a higher content size when window width is >= 600px
-        Gtk.DrawingArea draw_area {
-          hexpand: true;
-          vexpand: true;
-          margin-top: 10;
-          margin-bottom: 10;
-          margin-start: 10;
-          margin-end: 10;
-
-          content-height: 300;
-          content-width: 300;
-        }
-
-        styles [
-          "card"
-        ]
+        content-height: 300;
+        content-width: 300;
       }
     };
   };

--- a/src/views/game_page.go
+++ b/src/views/game_page.go
@@ -30,7 +30,6 @@ type GamePage struct {
 	gameInfoTitle *adw.WindowTitle
 
 	gameBox     *gtk.Box
-	boardView   *gtk.Box
 	drawingArea *gtk.DrawingArea
 }
 
@@ -49,7 +48,6 @@ func NewGamePage(parent *MainWindow, settings *gio.Settings, toastOverlay *adw.T
 	gameInfoTitle := builder.GetObject("game_info_title").Cast().(*adw.WindowTitle)
 
 	gameBox := builder.GetObject("game_box").Cast().(*gtk.Box)
-	boardView := builder.GetObject("board").Cast().(*gtk.Box)
 	drawArea := builder.GetObject("draw_area").Cast().(*gtk.DrawingArea)
 
 	board := backend.InitializeBoard(10, 10)
@@ -67,7 +65,6 @@ func NewGamePage(parent *MainWindow, settings *gio.Settings, toastOverlay *adw.T
 		gameInfoTitle: gameInfoTitle,
 
 		gameBox:     gameBox,
-		boardView:   boardView,
 		drawingArea: drawArea,
 	}
 
@@ -115,7 +112,7 @@ func (gp *GamePage) drawBoard(ctx *cairo.Context, width, height int) error {
 	xOffset := (width - rectWidth*boardCols) / 2
 	yOffset := (height - rectHeight*boardRows) / 2
 
-	gp.roundedRect(ctx, float64(xOffset), float64(yOffset), float64(rectWidth*boardCols), float64(rectHeight*boardRows), 6.0)
+	gp.roundedRect(ctx, float64(xOffset), float64(yOffset), float64(rectWidth*boardCols), float64(rectHeight*boardRows), 12.0)
 	ctx.Clip()
 
 	ctx.NewPath()

--- a/src/views/game_page.go
+++ b/src/views/game_page.go
@@ -109,13 +109,15 @@ func (gp *GamePage) drawBoard(ctx *cairo.Context, width, height int) error {
 	boardRows := gp.board.Rows
 	boardCols := gp.board.Columns
 
-	rectWidth := float64(width) / float64(boardCols)
-	rectHeight := float64(height) / float64(boardRows)
+	rectWidth := width / boardCols
+	rectHeight := height / boardRows
+	xOffset := (width - rectWidth*boardCols) / 2
+	yOffset := (height - rectHeight*boardRows) / 2
 
 	for row := 0; row < boardRows; row++ {
 		for col := 0; col < boardCols; col++ {
-			x := float64(rectWidth) * float64(col)
-			y := float64(rectHeight) * float64(row)
+			x := rectWidth*col + xOffset
+			y := rectHeight*row + yOffset
 
 			hexCode := backend.DefaultColors[boardMatrix[row][col]]
 			cairoRGB, err := utils.HexToCairoRGB(hexCode)
@@ -128,7 +130,7 @@ func (gp *GamePage) drawBoard(ctx *cairo.Context, width, height int) error {
 			blue := cairoRGB[2]
 
 			ctx.SetSourceRGB(red, green, blue)
-			ctx.Rectangle(x, y, float64(rectWidth), float64(rectHeight))
+			ctx.Rectangle(float64(x), float64(y), float64(rectWidth), float64(rectHeight))
 			ctx.Fill()
 		}
 	}

--- a/src/views/game_page.go
+++ b/src/views/game_page.go
@@ -3,6 +3,7 @@ package views
 import (
 	"fmt"
 	"log/slog"
+	"math"
 
 	"github.com/tfuxu/floodit/src/backend/utils"
 	"github.com/tfuxu/floodit/src/constants"
@@ -114,6 +115,10 @@ func (gp *GamePage) drawBoard(ctx *cairo.Context, width, height int) error {
 	xOffset := (width - rectWidth*boardCols) / 2
 	yOffset := (height - rectHeight*boardRows) / 2
 
+	gp.roundedRect(ctx, float64(xOffset), float64(yOffset), float64(rectWidth*boardCols), float64(rectHeight*boardRows), 6.0)
+	ctx.Clip()
+
+	ctx.NewPath()
 	for row := 0; row < boardRows; row++ {
 		for col := 0; col < boardCols; col++ {
 			x := rectWidth*col + xOffset
@@ -144,6 +149,15 @@ func (gp *GamePage) onDraw(area *gtk.DrawingArea, ctx *cairo.Context, width, hei
 		gp.toastOverlay.AddToast(adw.NewToast("Failed to retrieve colors for board points"))
 		slog.Error("Failed to convert hex values to Cairo compatible RGB channels:", "msg", err)
 	}
+}
+
+func (gp *GamePage) roundedRect(ctx *cairo.Context, x, y, width, height, cornerRadius float64) {
+	ctx.NewSubPath()
+	ctx.Arc(x+width-cornerRadius, y+cornerRadius, cornerRadius, -math.Pi/2, 0)
+	ctx.Arc(x+width-cornerRadius, y+height-cornerRadius, cornerRadius, 0, math.Pi/2)
+	ctx.Arc(x+cornerRadius, y+height-cornerRadius, cornerRadius, math.Pi/2, math.Pi)
+	ctx.Arc(x+cornerRadius, y+cornerRadius, cornerRadius, math.Pi, 3*math.Pi/2)
+	ctx.ClosePath()
 }
 
 func (gp *GamePage) onColorKeyboardUsed(colorName string) {


### PR DESCRIPTION
The first commit makes the cell size integer and aligns it to the pixel grid and thus removes the lines\artifacts between cells.
The second commit rounds the corners of the boar with a small radius.
The third commit - maybe controversial, since it changes the look significantly - removes the card container, enlarges the board to the size of it's former container and rounds the corners to the same value as the former container card.